### PR TITLE
Defer source loading

### DIFF
--- a/bin/squirrel.js
+++ b/bin/squirrel.js
@@ -17,6 +17,11 @@ var nomnom = require("nomnom")
       help: "Require a specific tilelive module",
       list: true
     },
+    defer: {
+      abbr: "d",
+      flag: true,
+      help: "Defer loading sources until a message is received",
+    },
     version: {
       abbr: "v",
       flag: true,

--- a/bin/squirrel.js
+++ b/bin/squirrel.js
@@ -21,7 +21,7 @@ var nomnom = require("nomnom")
     defer: {
       abbr: "d",
       flag: true,
-      help: "Defer loading sources until a message is received",
+      help: "Defer loading sources until a message is received"
     },
     version: {
       abbr: "v",

--- a/bin/squirrel.js
+++ b/bin/squirrel.js
@@ -9,6 +9,7 @@ var nomnom = require("nomnom")
     config: {
       abbr: "c",
       metavar: "CONFIG",
+      required: true,
       help: "Provide a configuration file"
     },
     require: {
@@ -50,9 +51,6 @@ var opts = nomnom.parse(argv);
 switch (true) {
   case opts.version:
     return process.exit();
-
-  case !opts.config:
-    return nomnom.print(nomnom.getUsage());
 
   case opts.stdin:
     return runStdin(opts);

--- a/lib/cacher.js
+++ b/lib/cacher.js
@@ -14,33 +14,28 @@ module.exports = function(opts) {
   // load and register tilelive modules
   require("tilelive-modules/loader")(tilelive, opts);
 
-  if (opts.uri) {
-    throw "For now you must use a config file in queue mode";
-  }
-
   //Load all sources
   var sources = {};
   var sinks = {};
 
-  if (opts.config) {
-    var config = require(path.resolve(opts.config));
-    debug("Loading " + Object.keys(config).length + " sources");
+  var config = require(path.resolve(opts.config));
 
+  if (opts.defer) {
+    debug("Loading " + Object.keys(config).length + " sources");
     var sourceLoadingPromises = [];
-    Object.keys(config).forEach(function(prefix) {
+    Object.keys(config).forEach(function(key) {
       (function() {
-        var key = prefix;
         var deferred = Q.defer();
         sourceLoadingPromises.push(deferred.promise);
-        tilelive.load(config[prefix]["source"], function(err, src) {
+        tilelive.load(config[key]["source"], function(err, src) {
           if (err) {
-            console.log("Error loading source " + config[prefix]["source"]);
+            console.log("Error loading source " + config[key]["source"]);
             return deferred.reject(err);
           }
           sources[key] = src;
-          tilelive.load(config[prefix]["destination"], function(err, dest) {
+          tilelive.load(config[key]["destination"], function(err, dest) {
             if (err) {
-              console.log("Error loading destination " + config[prefix]["destination"]);
+              console.log("Error loading destination " + config[key]["destination"]);
               return deferred.reject(err);
             }
             sinks[key] = dest;
@@ -53,41 +48,7 @@ module.exports = function(opts) {
     Q.all(sourceLoadingPromises).then(
       function() {
         debug("Finished loading sources");
-        if (opts.stdin) {
-          var pipe = process.stdin.pipe(require("split")());
-          var ended = false;
-          var requestCount = 0;
-          var finishedCount = 0;
-          pipe.on("data", function processLine(line) {
-            if (line.length) {
-              requestCount++;
-              processRequest(
-                line,
-                function() {
-                  debug("Request finished " + line);
-                  finishedCount++;
-                  if (ended && finishedCount == requestCount) {
-                    process.exit(0);
-                  }
-                },
-                function(err) {
-                  console.log("Error processing request: " + err);
-                }
-              );
-            }
-          });
-          pipe.on("end", function() {
-            ended = true;
-            if (requestCount == 0) {
-              debug("Finished reading STDIN with data read, exiting.");
-              process.exit(0);
-            } else {
-              debug("Finished reading STDIN, waiting for tile ");
-            }
-          });
-        } else {
-          listen();
-        }
+        start();
       },
       function(err) {
         debug("Error loading sources");
@@ -96,6 +57,46 @@ module.exports = function(opts) {
       }
     );
     sourceLoadingPromises = null;
+  } else {
+    start();
+  }
+
+  function start() {
+    if (opts.stdin) {
+      var pipe = process.stdin.pipe(require("split")());
+      var ended = false;
+      var requestCount = 0;
+      var finishedCount = 0;
+      pipe.on("data", function processLine(line) {
+        if (line.length) {
+          requestCount++;
+          processRequest(
+            line,
+            function() {
+              debug("Request finished " + line);
+              finishedCount++;
+              if (ended && finishedCount == requestCount) {
+                process.exit(0);
+              }
+            },
+            function(err) {
+              console.log("Error processing request: " + err);
+            }
+          );
+        }
+      });
+      pipe.on("end", function() {
+        ended = true;
+        if (requestCount == 0) {
+          debug("Finished reading STDIN with data read, exiting.");
+          process.exit(0);
+        } else {
+          debug("Finished reading STDIN, waiting for tile ");
+        }
+      });
+    } else {
+      listen();
+    }
   }
 
   function listen() {
@@ -114,7 +115,7 @@ module.exports = function(opts) {
         sub.on("data", function(note) {
           var subThis = this; //keep a ref to this around for use in later scopes
           debug("Received request " + note.toString());
-          processRequest(
+          processRequestMessage(
             note.toString(),
             function() {
               subThis.ack();
@@ -128,11 +129,41 @@ module.exports = function(opts) {
     });
   }
 
-  function processRequest(request, success, errorC) {
+  function processRequestMessage(request, success, errorC) {
     var messageComponents = request.split("+");
     var sourceName = messageComponents[0];
-
     var tileComponents = messageComponents[1].split("/");
+
+    var source = sources[sourceName];
+    var dest = sinks[sourceName];
+    if (source == null) {
+      if (opts.defer) {
+        tilelive.load(config[sourceName]["source"], function(err, src) {
+          if (err) {
+            console.log("Error loading source " + config[sourceName]["source"]);
+            return success(err);
+          }
+          sources[sourceName] = src;
+          tilelive.load(config[sourceName]["destination"], function(err, dest) {
+            if (err) {
+              console.log("Error loading destination " + config[sourceName]["destination"]);
+              return errorC(err);
+            }
+            sinks[sourceName] = dest;
+            processRequest(tileComponents, source, dest, success, errorC);
+          });
+        });
+      } else {
+        //source not found, send it back to the queue
+        console.log("Error: source " + sourceName + " not found");
+        return errorC(null);
+      }
+    } else {
+      processRequest(tileComponents, source, dest, success, errorC);
+    }
+  }
+
+  function processRequest(tileComponents, source, dest, success, errorC) {
     var z = parseInt(tileComponents[0]);
     var startX, endX, startY, endY;
     var xComponents = tileComponents[1].split("-");
@@ -149,15 +180,6 @@ module.exports = function(opts) {
     } else {
       startY = parseInt(yComponents[0]);
       endY = parseInt(yComponents[1]);
-    }
-
-    var source = sources[sourceName];
-    var dest = sinks[sourceName];
-    if (source == null) {
-      //source not found, send it back to the queue
-      console.log("Error: source " + sourceName + " not found");
-      errorC(null);
-      return;
     }
 
     debug("opening source " + config[sourceName]["destination"] + " for writing");

--- a/lib/cacher.js
+++ b/lib/cacher.js
@@ -19,8 +19,9 @@ module.exports = function(opts) {
   var sinks = {};
 
   var config = require(path.resolve(opts.config));
-
   if (opts.defer) {
+    start();
+  } else {
     debug("Loading " + Object.keys(config).length + " sources");
     var sourceLoadingPromises = [];
     Object.keys(config).forEach(function(key) {
@@ -57,8 +58,6 @@ module.exports = function(opts) {
       }
     );
     sourceLoadingPromises = null;
-  } else {
-    start();
   }
 
   function start() {


### PR DESCRIPTION
Add an option to defer loading  sources until a message is received. This is necessary to make this work properly in a docker-compose environment, where we are bring up a container to do an import, and a worker container at the same time, because if the source is loaded on launch, it will fail because the importer hasn't made the tables yet.